### PR TITLE
chore: update Node.js version to 22 and pnpm version to 10 in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,30 +16,19 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - uses: pnpm/action-setup@v3
+          node-version: 22
+          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 10
           run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install
@@ -51,7 +40,7 @@ jobs:
         if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libsoup3.0-dev libappindicator3-dev librsvg2-dev patchelf
 
       - uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/build.yaml` file. The changes aim to update dependencies and improve caching mechanisms.

Dependency updates:

* Updated the Node.js version from 20 to 22 and added caching for `pnpm` to improve build efficiency. (`[.github/workflows/build.yamlR19-L43](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R19-L43)`)
* Updated `pnpm` version from 8 to 10 and changed the `pnpm/action-setup` version to v4. (`[.github/workflows/build.yamlR19-L43](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R19-L43)`)

Package installation updates:

* Replaced `libwebkit2gtk-4.0-dev` with `libwebkit2gtk-4.1-dev` and added `libsoup3.0-dev` to the list of packages installed on Ubuntu 20.04. (`[.github/workflows/build.yamlL54-R43](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L54-R43)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the deployment pipeline with updated runtime environments and improved dependency management.
  - Refined system dependency installations for better performance and compatibility on Ubuntu systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->